### PR TITLE
Implement reordering items in the menu by drag'n'drop

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -102,3 +102,23 @@ button:focus {
 	display: block;
 	clear: both;
 }
+
+.scrollbar::-webkit-scrollbar {
+	width: 8px;
+	background: var(--gray5);
+	border-radius: 3px;
+	cursor: pointer;
+}
+
+.scrollbar::-webkit-scrollbar-thumb {
+	border: 2px solid var(--gray5);
+	background: var(--black);
+	border-radius: 8px;
+}
+
+
+/* FF, Edge */
+.scrollbar {
+	scrollbar-width: thin;
+  	scrollbar-color: var(--black) var(--gray5);
+}

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -119,6 +119,8 @@ button:focus {
 
 /* FF, Edge */
 .scrollbar {
+	height: 100%;
+	overflow-y: auto;
 	scrollbar-width: thin;
   	scrollbar-color: var(--black) var(--gray5);
 }

--- a/src/dataSlice.js
+++ b/src/dataSlice.js
@@ -152,8 +152,8 @@ const itemsSlice = createSlice({
         },
 
         reorderFeatures: (state, action) => {
-            const { subsectionID, newOrder } = action.payload
-            state.subsections[subsectionID].children = newOrder
+            const { subsecID, newOrder } = action.payload
+            state.subsections[subsecID].children = newOrder
         },
 
 

--- a/src/dataSlice.js
+++ b/src/dataSlice.js
@@ -141,9 +141,19 @@ const itemsSlice = createSlice({
         },
 
 
-        setSectionsOrder: (state, action) => {
+        reorderSections: (state, action) => {
             // action.payload is an array of ids in a new order;
             state.sections.ids = action.payload;
+        },
+
+        reorderSubsections: (state, action) => {
+            const { sectionID, newOrder } = action.payload
+            state.sections.byID[sectionID].children = newOrder
+        },
+
+        reorderFeatures: (state, action) => {
+            const { subsectionID, newOrder } = action.payload
+            state.subsections[subsectionID].children = newOrder
         },
 
 
@@ -165,7 +175,9 @@ export const {
     removeSection,
     removeSubsection,
     removeFeature,
-    setSectionsOrder,
+    reorderSections,
+    reorderSubsections,
+    reorderFeatures,
     addContentItem 
 } = actions;
 
@@ -556,7 +568,7 @@ export const getSections = () => async dispatch => {
 
     batch(() => {
         dispatch(addSections(sections))
-        dispatch(setSectionsOrder(ids))
+        dispatch(reorderSections(ids))
     })
 }
 

--- a/src/dataSlice.js
+++ b/src/dataSlice.js
@@ -52,20 +52,22 @@ const itemsSlice = createSlice({
             })
         },
 
+        moveSection: (state, action) => {
+            const { current, target } = action.payload;
+            const ids = state.sections.ids;
+            ids.splice(target, 0, ids.splice(current, 1)[0]);
+        },
+
         addContentItem: (state, action) => {
             state.content[action.payload.id] = action.payload;
         },
-
-        removeContentItem: (state, action) => {
-            delete state.content[action.payload];
-        }
     }
 });
 
 
 const { reducer, actions } = itemsSlice;
 
-export const { addItems, removeItems, addContentItem } = actions;
+export const { addItems, removeItems, moveSection, addContentItem } = actions;
 
 export default reducer;
 

--- a/src/dataSlice.js
+++ b/src/dataSlice.js
@@ -44,21 +44,17 @@ const itemsSlice = createSlice({
 
         addSubsections: (state, action) => {
             const items = action.payload;
-            const sec = items[0].sectionID
 
             items.forEach(item => {
                 state.subsections[item.id] = item
-                state.sections.byID[sec].children.push(item.id)
             })
         },
 
         addFeatures: (state, action) => {
             const items = action.payload;
-            const sub = items[0].subsectionID
 
             items.forEach(item => {
                 state.features[item.id] = item
-                state.subsections[sub].children.push(item.id)
             })
         },
 

--- a/src/features/Content/ContentEditor.js
+++ b/src/features/Content/ContentEditor.js
@@ -24,7 +24,7 @@ const EditableContainer = styled.div`
 
 const Wrapper = styled(motion.div)`
     position: relative;
-    margin: 6px;
+    margin: 6px 9px;
     height: calc(100% - 12px);
     font-size: 1.4rem;
     color: var(--gray1); 

--- a/src/features/Content/editor.js
+++ b/src/features/Content/editor.js
@@ -2,7 +2,6 @@ import { createEditor, Editor, Node, Text, Transforms } from 'slate';
 import { withReact } from 'slate-react';
 import { withHistory } from 'slate-history';
 import Prism from 'prismjs';
-import isUrl from 'is-url';
 
 
 

--- a/src/features/Nav/Nav.js
+++ b/src/features/Nav/Nav.js
@@ -3,7 +3,7 @@ import styled from 'styled-components/macro';
 import { Route } from 'react-router-dom';
 
 import SectionMenu from 'features/SectionMenu/SectionMenu';
-import SubsectionMenu from 'features/SubsectionMenu/SubsectionMenu';
+import SubsectionsContainer from 'features/SubsectionMenu/SubsectionsContainer';
 
 const StyledNav = styled.nav`
     box-shadow: 0 0 8px 1px var(--black);
@@ -17,7 +17,7 @@ const Nav = () => (
     <StyledNav>
         <SectionMenu />
         <Route path='/:sectionName?/:subsecName?/:featureName?'>
-            <SubsectionMenu />
+            <SubsectionsContainer />
         </Route>
     </StyledNav>
 )

--- a/src/features/SectionMenu/SectionLink.js
+++ b/src/features/SectionMenu/SectionLink.js
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import styled from 'styled-components/macro';
 import { motion, useMotionValue } from 'framer-motion';
 import { NavLink } from 'react-router-dom';
+import { scroll } from 'utils'
 
 
 const SectionLink = ({ 
@@ -79,21 +80,6 @@ const SectionLink = ({
         </StyledLink>
     )
 }
-
-
-const scroll = (scrollbar, y, dragOrigin) => {
-    scrollbar.scrollBy(0, y);
-
-    // adjust elem's position when scrolling
-    const scroll = scrollbar.scrollTop;
-    const scrollH = scrollbar.scrollHeight;
-    const clientH = scrollbar.clientHeight;
-
-    if (scroll > 0 && scroll < scrollH - clientH) {
-        dragOrigin.set(dragOrigin.get() + y)
-    }
-}
-
 
 
 const StyledLink = styled(motion.li)`

--- a/src/features/SectionMenu/SectionLink.js
+++ b/src/features/SectionMenu/SectionLink.js
@@ -1,16 +1,67 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components/macro';
-import { motion } from 'framer-motion';
+import { motion, useMotionValue } from 'framer-motion';
 import { NavLink } from 'react-router-dom';
 
+
+const SectionLink = ({ label, i, moveItem }) => {
+    const [ isDragging, setDragging ] = useState(false);
+    const dragOriginY = useMotionValue(0);
+
+    return (
+        <StyledLink
+            // variants are for the initialization animation only
+            // not related to d'n'd
+            variants={variants}
+
+            drag='y'
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragElastic={1}
+            dragOriginY={dragOriginY}
+            isDragging={isDragging}
+            
+            onDrag={(e, info) => {
+                const dragged = info.point.y;
+                // if dragged elem was moved down by more than 32 px,
+                // swap positions with the next elem
+                if (dragged > 32) moveItem(i, i + 1)
+                // if it was moved up, swap with prev elem
+                if (dragged < -32) moveItem(i, i - 1)
+            }}
+
+            onDragStart={() => setDragging(true)}
+            onDragEnd={() => setDragging(false)}
+            positionTransition={({ delta }) => {
+                if (isDragging) {
+                    dragOriginY.set(dragOriginY.get() + delta.y)
+                }
+                return !isDragging;
+            }}
+        >
+
+            <NavLink to={`/${label}`} activeClassName='active'>
+                {label}
+            </NavLink>
+
+        </StyledLink>
+    )
+}
+
+
 const StyledLink = styled(motion.li)`
-    display: block;
+    position: relative;
     margin: 2px 0;
     background-color: var(--gray5);
+    z-index: ${props => props.isDragging ? 5 : 0 };
+    transition-delay: ${props => props.isDragging ? 0 : 'z-index 0.3' };
+    border: ${props => props.isDragging ? 
+        '1px solid var(--black)' : 
+        '1px solid transparent' };
+    box-shadow : ${props => props.isDragging ? '0 0 18px -3px black' : ''};
 
     a {
         display: block;
-        padding: 15px;
+        padding: 13px;
         height: 100%;
         border-radius: 3px;
         color: var(--gray1);
@@ -30,28 +81,18 @@ const StyledLink = styled(motion.li)`
 `;
 
 
-const SectionLink = ({ label }) => (
-    <StyledLink variants={item}>
-
-        <NavLink to={`/${label}`} activeClassName='active'>
-            {label}
-        </NavLink>
-
-    </StyledLink>
-)
-
-
-const item = {
+const variants = {
     hidden: { 
         opacity: 0,
-        scaleY: 0.6,
-        y: -10
+        scale: 0.7,
+        y: -20
     },
     visible: { 
         opacity: 1,
-        scaleY: 1,
+        scale: 1,
         y: 0
     },
 }
+
 
 export default SectionLink;

--- a/src/features/SectionMenu/SectionLink.js
+++ b/src/features/SectionMenu/SectionLink.js
@@ -7,13 +7,22 @@ import { NavLink } from 'react-router-dom';
 const SectionLink = ({ 
     label, 
     i, 
-    container,
+    scrollbar,
+    ul,
     moveItem, 
     updateDB 
 }) => {
     const [ isDragging, setDragging ] = useState(false);
+    const [ boundary, setBoundary ] = useState(false);
     const elemRef = useRef();
     const dragOriginY = useMotionValue(0);
+
+    const isOnTop = () => {
+        const el = elemRef.current.getBoundingClientRect();
+        const ulTop = ul.current.getBoundingClientRect().top;
+
+        return el.top <= ulTop;
+    }
 
     return (
         <StyledLink
@@ -24,11 +33,18 @@ const SectionLink = ({
             ref={elemRef}
             drag='y'
             dragConstraints={{ top: 0, bottom: 0 }}
-            dragElastic={1}
+            dragElastic={boundary ? 0.01 : 1}
             dragOriginY={dragOriginY}
             isDragging={isDragging}
             
             onDrag={(e, info) => {
+
+                if (isOnTop()) {
+                    setBoundary(true)
+                } else if (boundary) {
+                    setBoundary(false)
+                }
+
                 // if the dragged elem was moved by 32px down, 
                 // swap it's position with the next elem
                 if (info.point.y > 30) moveItem(i, i + 1);
@@ -36,7 +52,7 @@ const SectionLink = ({
                 if (info.point.y < -30) moveItem(i, i - 1);
 
                 // scroll while dragging
-                scroll(container.current, info.delta.y, dragOriginY)
+                scroll(scrollbar.current, info.delta.y, dragOriginY)
             }}
 
             onDragStart={() => {

--- a/src/features/SectionMenu/SectionLink.js
+++ b/src/features/SectionMenu/SectionLink.js
@@ -56,31 +56,29 @@ const SectionLink = ({ label, i, moveItem, updateDB }) => {
 const StyledLink = styled(motion.li)`
     position: relative;
     margin: 2px 0;
-    background-color: var(--gray5);
     z-index: ${props => props.isDragging ? 5 : 0 };
-    transition-delay: ${props => props.isDragging ? 0 : 'z-index 0.3' };
     border: ${props => props.isDragging ? 
         '1px solid var(--black)' : 
         '1px solid transparent' };
-    box-shadow : ${props => props.isDragging ? '0 0 18px -3px black' : ''};
+    box-shadow : ${props => props.isDragging ? '0 0 20px -4px black' : ''};
 
     a {
         display: block;
         padding: 13px;
         height: 100%;
         border-radius: 3px;
+        background: ${props => props.isDragging ? 'var(--gray4)' : 'var(--gray5)'};
         color: var(--gray1);
         transition: .2s;
     }
 
     a:hover {
         background: var(--gray4);
-        color: var(--white);
     }
 
     a.active {
         background: var(--gray4);
-        box-shadow: inset 0 0 15px 0 var(--gray6);
+        box-shadow: inset 0 0 15px -3px var(--gray6);
         color: var(--white);
     }
 `;

--- a/src/features/SectionMenu/SectionLink.js
+++ b/src/features/SectionMenu/SectionLink.js
@@ -1,23 +1,29 @@
 import React from 'react';
 import styled from 'styled-components/macro';
+import { motion } from 'framer-motion';
 import { NavLink } from 'react-router-dom';
 
-const StyledLink = styled(NavLink)`
-    padding: 15px;
+const StyledLink = styled(motion.li)`
     display: block;
-    height: 100%;
-    transition: .2s;
-    color: var(--gray1);
+    margin: 2px 0;
     background-color: var(--gray5);
 
-    &:hover {
+    a {
+        display: block;
+        padding: 15px;
+        height: 100%;
+        border-radius: 3px;
+        color: var(--gray1);
+        transition: .2s;
+    }
+
+    a:hover {
         background: var(--gray4);
-        box-shadow: inset 0 0 10px 0 var(--gray6);
         color: var(--white);
     }
 
-    &.active {
-        background-color: var(--gray4);
+    a.active {
+        background: var(--gray4);
         box-shadow: inset 0 0 15px 0 var(--gray6);
         color: var(--white);
     }
@@ -25,9 +31,27 @@ const StyledLink = styled(NavLink)`
 
 
 const SectionLink = ({ label }) => (
-    <StyledLink to={`/${label}`} activeClassName='active'>
-        {label}
+    <StyledLink variants={item}>
+
+        <NavLink to={`/${label}`} activeClassName='active'>
+            {label}
+        </NavLink>
+
     </StyledLink>
 )
+
+
+const item = {
+    hidden: { 
+        opacity: 0,
+        scaleY: 0.6,
+        y: -10
+    },
+    visible: { 
+        opacity: 1,
+        scaleY: 1,
+        y: 0
+    },
+}
 
 export default SectionLink;

--- a/src/features/SectionMenu/SectionLink.js
+++ b/src/features/SectionMenu/SectionLink.js
@@ -4,7 +4,7 @@ import { motion, useMotionValue } from 'framer-motion';
 import { NavLink } from 'react-router-dom';
 
 
-const SectionLink = ({ label, i, moveItem }) => {
+const SectionLink = ({ label, i, moveItem, updateDB }) => {
     const [ isDragging, setDragging ] = useState(false);
     const dragOriginY = useMotionValue(0);
 
@@ -22,15 +22,20 @@ const SectionLink = ({ label, i, moveItem }) => {
             
             onDrag={(e, info) => {
                 const dragged = info.point.y;
-                // if dragged elem was moved down by more than 32 px,
-                // swap positions with the next elem
-                if (dragged > 32) moveItem(i, i + 1)
-                // if it was moved up, swap with prev elem
-                if (dragged < -32) moveItem(i, i - 1)
+
+                // if the dragged elem was moved by 32px down, 
+                // swap it's position with the next elem
+                if (dragged > 32) moveItem(i, i + 1);
+
+                // if it was moved up, swap with prev elem 
+                if (dragged < -32) moveItem(i, i - 1);
             }}
 
             onDragStart={() => setDragging(true)}
-            onDragEnd={() => setDragging(false)}
+            onDragEnd={() => {
+                setDragging(false);
+                updateDB();
+            }}
             positionTransition={({ delta }) => {
                 if (isDragging) {
                     dragOriginY.set(dragOriginY.get() + delta.y)

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components/macro';
 import { motion } from 'framer-motion';
 
@@ -6,7 +6,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { getSections, setSectionsOrder } from '../../dataSlice';
 import { updateSectionsOrderInDB } from 'utils/db';
 
-import Scrollbar from 'components/Scrollbar';
 import Spinner from 'components/Spinner';
 import SectionLink from './SectionLink';
 
@@ -23,11 +22,14 @@ const SectionMenu = () => {
 
     const isAdmin = useSelector(state => state.user && state.user.isAdmin)
 
+    const container = useRef();
+
     useEffect(() => {
         dispatch(getSections());
     }, [])
 
     if (!ids.length) return <StyledMenu><Spinner /></StyledMenu>
+
 
     // this function will be invoked
     // every time the dragged elem was moved 
@@ -35,6 +37,7 @@ const SectionMenu = () => {
     const moveItem = (current, target) => {
         // the args are the current and the target indexes
         // of the dragged elem in the ids array
+        if (target < 0) return;
         const newOrder = [...ids];
 
         // delete the elem from the ids array
@@ -45,29 +48,32 @@ const SectionMenu = () => {
         dispatch(setSectionsOrder(newOrder)) 
     }
 
+
     // invoked onDragEnd
     const updateDB = () => {
         if (isAdmin) updateSectionsOrderInDB(ids)
     }
 
+
     return (
         <StyledMenu>
-            <Scrollbar>
-                <motion.ul variants={list} 
-                    initial='hidden' 
-                    animate='visible' >
+            <motion.ul ref={container}
+                className='scrollbar'
+                variants={list} 
+                initial='hidden' 
+                animate='visible' >
 
-                    {ids.map((id, i) => (
-                        <SectionLink key={id} 
-                            label={sections[id].name}
-                            i={i}
-                            updateDB={updateDB}
-                            moveItem={moveItem}
-                        />
-                    ))}
+                {ids.map((id, i) => (
+                    <SectionLink key={id} 
+                        label={sections[id].name}
+                        i={i}
+                        container={container}
+                        updateDB={updateDB}
+                        moveItem={moveItem}
+                    />
+                ))}
 
-                </motion.ul>
-            </Scrollbar>
+            </motion.ul>
         </StyledMenu>
     )
 }
@@ -77,14 +83,15 @@ const SectionMenu = () => {
 const StyledMenu = styled.section`
     position: relative;
     background: var(--gray6);
-    padding: 5px 0 5px 8px;
     flex-basis: 160px;
+    padding: 5px 0 5px 8px;
 
     ul {
         background: var(--black);
         margin-right: 11px;
         height: 100%;
         transition: background 2s;
+        overflow-y: auto;
     }
 `;
 

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import { useSelector, useDispatch } from 'react-redux';
 import { getSections, setSectionsOrder } from '../../dataSlice';
 import { updateSectionsOrderInDB } from 'utils/db';
+import { arrayMove } from 'utils'
 
 import Spinner from 'components/Spinner';
 import SectionLink from './SectionLink';
@@ -36,18 +37,7 @@ const SectionMenu = () => {
     // every time the dragged elem was moved 
     // by more than 32px up or down
     const moveItem = (current, target) => {
-        // the args are the current and the target indexes
-        // of the dragged elem in the ids array
-
-        if (target < 0 || target > ids.length - 1) return;
-
-        const newOrder = [...ids];
-
-        // delete the elem from the ids array
-        const el = newOrder.splice(current, 1)[0];
-        // and insert it in the target position
-        newOrder.splice(target, 0, el);
-
+        const newOrder = arrayMove(ids, current, target)
         dispatch(setSectionsOrder(newOrder)) 
     }
 

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -22,7 +22,8 @@ const SectionMenu = () => {
 
     const isAdmin = useSelector(state => state.user && state.user.isAdmin)
 
-    const container = useRef();
+    const scrollbar = useRef();
+    const ul = useRef();
 
     useEffect(() => {
         dispatch(getSections());
@@ -37,7 +38,9 @@ const SectionMenu = () => {
     const moveItem = (current, target) => {
         // the args are the current and the target indexes
         // of the dragged elem in the ids array
-        if (target < 0) return;
+
+        if (target < 0 || target > ids.length - 1) return;
+
         const newOrder = [...ids];
 
         // delete the elem from the ids array
@@ -57,23 +60,27 @@ const SectionMenu = () => {
 
     return (
         <StyledMenu>
-            <motion.ul ref={container}
-                className='scrollbar'
+            <motion.div className='scrollbar'
+                ref={scrollbar}
                 variants={list} 
                 initial='hidden' 
-                animate='visible' >
+                animate='visible'>
 
-                {ids.map((id, i) => (
-                    <SectionLink key={id} 
-                        label={sections[id].name}
-                        i={i}
-                        container={container}
-                        updateDB={updateDB}
-                        moveItem={moveItem}
-                    />
-                ))}
+                <ul ref={ul} >
 
-            </motion.ul>
+                    {ids.map((id, i) => (
+                        <SectionLink key={id} 
+                            label={sections[id].name}
+                            i={i}
+                            scrollbar={scrollbar}
+                            ul={ul}
+                            updateDB={updateDB}
+                            moveItem={moveItem}
+                        />
+                    ))}
+
+                </ul>
+            </motion.div>
         </StyledMenu>
     )
 }
@@ -86,12 +93,15 @@ const StyledMenu = styled.section`
     flex-basis: 160px;
     padding: 5px 0 5px 8px;
 
-    ul {
-        background: var(--black);
-        margin-right: 11px;
+    .scrollbar {
         height: 100%;
+        background: var(--black);
         transition: background 2s;
         overflow-y: auto;
+    }
+
+    ul {
+        max-height: 100%;
     }
 `;
 

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -43,8 +43,16 @@ const list = {
 }
 
 const item = {
-    hidden: { opacity: 0 },
-    visible: { opacity: 1 },
+    hidden: { 
+        opacity: 0,
+        scaleY: 0.6,
+        y: -10
+    },
+    visible: { 
+        opacity: 1,
+        scaleY: 1,
+        y: 0
+    },
 }
 
 

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -13,6 +13,7 @@ const StyledMenu = styled.section`
     position: relative;
     background: var(--gray6);
     padding: 5px;
+    padding-left: 8px;
     padding-right: 0;
     flex-basis: 160px;
 

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -9,23 +9,47 @@ import Scrollbar from 'components/Scrollbar';
 import Spinner from 'components/Spinner';
 import SectionLink from './SectionLink';
 
+
+const SectionMenu = () => {
+    const dispatch = useDispatch();
+    const sectionsObj = useSelector(state => state.data.sections.byID);
+    const sections = Object.values(sectionsObj);
+
+    useEffect(() => {
+        dispatch(getSections());
+    }, [])
+
+    if (!sections.length) return <StyledMenu><Spinner /></StyledMenu>
+
+    return (
+        <StyledMenu>
+            <Scrollbar>
+                <motion.ul variants={list} 
+                    initial='hidden' 
+                    animate='visible' >
+
+                    {sections.map(sec => (
+                        <SectionLink key={sec.id} 
+                            label={sec.name} />
+                    ))}
+
+                </motion.ul>
+            </Scrollbar>
+        </StyledMenu>
+    )
+}
+
+
+
 const StyledMenu = styled.section`
     position: relative;
     background: var(--gray6);
-    padding: 5px;
-    padding-left: 8px;
-    padding-right: 0;
+    padding: 5px 0 5px 8px;
     flex-basis: 160px;
 
     ul {
-        background: var(--gray5);
-        margin-right: 10px;
+        margin-right: 11px;
         height: 100%;
-    }
-
-    li {
-        display: block;
-        border-bottom: 3px solid var(--gray6);
     }
 `;
 
@@ -43,46 +67,5 @@ const list = {
     }
 }
 
-const item = {
-    hidden: { 
-        opacity: 0,
-        scaleY: 0.6,
-        y: -10
-    },
-    visible: { 
-        opacity: 1,
-        scaleY: 1,
-        y: 0
-    },
-}
-
-
-const SectionMenu = () => {
-    const dispatch = useDispatch();
-    const sectionsObj = useSelector(state => state.data.sections.byID);
-    const sections = Object.values(sectionsObj);
-
-    useEffect(() => {
-        dispatch(getSections());
-    }, [])
-
-    if (!sections.length) return <StyledMenu><Spinner /></StyledMenu>
-
-    return (
-        <StyledMenu>
-            <Scrollbar>
-                <motion.ul variants={list} 
-                        initial='hidden' 
-                        animate='visible' >
-                    {sections.map(sec => (
-                        <motion.li key={sec.id} variants={item} >
-                            <SectionLink label={sec.name} />
-                        </motion.li>
-                    ))}
-                </motion.ul>
-            </Scrollbar>
-        </StyledMenu>
-    )
-}
 
 export default SectionMenu;

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -84,10 +84,8 @@ const StyledMenu = styled.section`
     padding: 5px 0 5px 8px;
 
     .scrollbar {
-        height: 100%;
         background: var(--black);
         transition: background 2s;
-        overflow-y: auto;
     }
 
     ul {

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -3,7 +3,7 @@ import styled from 'styled-components/macro';
 import { motion } from 'framer-motion';
 
 import { useSelector, useDispatch } from 'react-redux';
-import { getSections, setSectionsOrder } from '../../dataSlice';
+import { getSections, reorderSections } from '../../dataSlice';
 import { updateSectionsOrderInDB } from 'utils/db';
 import { arrayMove } from 'utils'
 
@@ -21,7 +21,7 @@ const SectionMenu = () => {
     // for order in which items will appear in the menu
     const ids = useSelector(state => state.data.sections.ids);
 
-    const isAdmin = useSelector(state => state.user && state.user.isAdmin)
+    const isAdmin = useSelector(state => state.user?.isAdmin)
 
     const scrollbar = useRef();
     const ul = useRef();
@@ -38,7 +38,7 @@ const SectionMenu = () => {
     // by more than 32px up or down
     const moveItem = (current, target) => {
         const newOrder = arrayMove(ids, current, target)
-        dispatch(setSectionsOrder(newOrder)) 
+        dispatch(reorderSections(newOrder)) 
     }
 
 

--- a/src/features/SectionMenu/SectionMenu.js
+++ b/src/features/SectionMenu/SectionMenu.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components/macro';
-import { useSelector, useDispatch } from 'react-redux';
 import { motion } from 'framer-motion';
 
-import { getSections } from '../../dataSlice';
+import { useSelector, useDispatch } from 'react-redux';
+import { getSections, moveSection } from '../../dataSlice';
 
 import Scrollbar from 'components/Scrollbar';
 import Spinner from 'components/Spinner';
@@ -12,14 +12,14 @@ import SectionLink from './SectionLink';
 
 const SectionMenu = () => {
     const dispatch = useDispatch();
-    const sectionsObj = useSelector(state => state.data.sections.byID);
-    const sections = Object.values(sectionsObj);
+    const sections = useSelector(state => state.data.sections.byID);
+    const ids = useSelector(state => state.data.sections.ids);
 
     useEffect(() => {
         dispatch(getSections());
     }, [])
 
-    if (!sections.length) return <StyledMenu><Spinner /></StyledMenu>
+    if (!ids.length) return <StyledMenu><Spinner /></StyledMenu>
 
     return (
         <StyledMenu>
@@ -28,9 +28,13 @@ const SectionMenu = () => {
                     initial='hidden' 
                     animate='visible' >
 
-                    {sections.map(sec => (
-                        <SectionLink key={sec.id} 
-                            label={sec.name} />
+                    {ids.map((id, i) => (
+                        <SectionLink key={id} 
+                            i={i}
+                            moveItem={(current, target) => {
+                                dispatch(moveSection({ current, target })
+                            )}}
+                            label={sections[id].name} />
                     ))}
 
                 </motion.ul>
@@ -48,8 +52,10 @@ const StyledMenu = styled.section`
     flex-basis: 160px;
 
     ul {
+        background: var(--black);
         margin-right: 11px;
         height: 100%;
+        transition: background 2s;
     }
 `;
 
@@ -63,7 +69,8 @@ const list = {
             duration: 0.3,
             when: 'beforeChildren',
             staggerChildren: 0.08,
-        }
+        },
+        transitionEnd: { background: 'var(--gray6)'}
     }
 }
 

--- a/src/features/SubsectionMenu/FeatureItem.js
+++ b/src/features/SubsectionMenu/FeatureItem.js
@@ -1,41 +1,88 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components/macro';
+import { motion, useMotionValue } from 'framer-motion'
 import { NavLink } from 'react-router-dom'
 
 
-const StyledItem = styled.li`
-    flex-basis: 50%;
+const FeatureItem = ({ 
+    i,
+    feature,
+    moveItem 
+}) => {
+    const [ isDragging, setDragging ] = useState(false)
+    const dragOriginY = useMotionValue(0);
+
+    return (
+        <StyledItem drag='y'
+            isDragging={isDragging}
+            dragElastic={1}
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragOriginY={dragOriginY}
+            animate={isDragging ? 
+                { zIndex: 5 } 
+                : 
+                { zIndex: 1, transition: { delay: .3} }
+            }
+
+            onDrag={(e, info) => {
+                const dragged = info.point.y;
+
+                if (dragged > 18) {
+                    moveItem(i, i + 1)
+                } 
+
+                if (dragged < -18) {
+                    moveItem(i, i - 1)
+                }
+            }}
+
+            onDragStart={() => setDragging(true)}
+            onDragEnd={() => setDragging(false)}
+
+            positionTransition={({ delta }) => {
+                if (isDragging) {
+                    dragOriginY.set(dragOriginY.get() + delta.y)
+                }
+                return !isDragging
+            }}
+
+            >
+
+            <NavLink activeClassName='active'
+                to={`/${feature.sectionName}/${feature.subsectionName}/${feature.name}`} >
+                    {feature.name}
+            </NavLink>
+        </StyledItem>
+    )
+}
+
+
+const StyledItem = styled(motion.li)`
     flex-grow: 1;
-    background: var(--gray6);
+    box-shadow: ${props => props.isDragging && '0 0 25px -5px black'};
 
     a {
         display: block;
+        transform: scale(${props => props.isDragging ? 1.15 : 1});
         height: 100%;
         padding-top: 8px;
         font-size: 1.4rem;
-        color: var(--gray2);
-        transition: .2s;
+        text-align: left;
+        padding-left: 36px;
+        background: ${props => props.isDragging ? 'var(--black)' : 'var(--gray6)'};
+        color: ${props => props.isDragging ? 'var(--orange2)' : 'var(--gray2)'};
+        transition: .2s, transform .35s;
     }
 
     a:hover {
-        background: var(--gray5);
+        background: var(--black);
         color: var(--orange2);
     }
 
     a.active {
-        background: var(--gray5);
+        background: var(--black);
         color: var(--orange2);
     }
 `;
-
-
-const FeatureItem = ({ feature }) => (
-    <StyledItem>
-        <NavLink activeClassName='active'
-            to={`/${feature.sectionName}/${feature.subsectionName}/${feature.name}`} >
-                {feature.name}
-        </NavLink>
-    </StyledItem>
-)
 
 export default FeatureItem;

--- a/src/features/SubsectionMenu/FeatureItem.js
+++ b/src/features/SubsectionMenu/FeatureItem.js
@@ -7,7 +7,8 @@ import { NavLink } from 'react-router-dom'
 const FeatureItem = ({ 
     i,
     feature,
-    moveItem 
+    moveItem,
+    updateOrderInDB
 }) => {
     const [ isDragging, setDragging ] = useState(false)
     const dragOriginY = useMotionValue(0);
@@ -37,7 +38,10 @@ const FeatureItem = ({
             }}
 
             onDragStart={() => setDragging(true)}
-            onDragEnd={() => setDragging(false)}
+            onDragEnd={() => {
+                setDragging(false)
+                updateOrderInDB()
+            }}
 
             positionTransition={({ delta }) => {
                 if (isDragging) {

--- a/src/features/SubsectionMenu/FeatureItem.js
+++ b/src/features/SubsectionMenu/FeatureItem.js
@@ -6,22 +6,25 @@ import { NavLink } from 'react-router-dom'
 const StyledItem = styled.li`
     flex-basis: 50%;
     flex-grow: 1;
-    background: var(--gray5);
+    background: var(--gray6);
 
     a {
         display: block;
         height: 100%;
         padding-top: 8px;
         font-size: 1.4rem;
+        color: var(--gray2);
         transition: .2s;
     }
 
     a:hover {
-        background: var(--gray4);
+        background: var(--gray5);
+        color: var(--orange2);
     }
 
     a.active {
-        background: var(--gray4);
+        background: var(--gray5);
+        color: var(--orange2);
     }
 `;
 

--- a/src/features/SubsectionMenu/FeatureList.js
+++ b/src/features/SubsectionMenu/FeatureList.js
@@ -1,32 +1,45 @@
 import React from 'react';
 import styled from 'styled-components/macro';
+import { useDispatch } from 'react-redux'
+import { arrayMove } from 'utils'
+import { reorderFeatures } from 'dataSlice'
 
 import FeatureItem from './FeatureItem';
 
+
+const FeatureList = ({ 
+    subsecID,
+    ids,
+    features, 
+    isOpen 
+}) => {
+    const dispatch = useDispatch()
+
+    const moveItem = (current, target) => {
+        const newOrder = arrayMove(ids, current, target);
+        if (ids === newOrder) return;
+        dispatch(reorderFeatures({ subsecID, newOrder }))
+    }
+
+    return (
+        <StyledList height={isOpen ? features.length * 34 + 'px' : '0px'}>
+
+            {features.map((feature, i) => (
+                <FeatureItem i={i}
+                    key={feature.id} 
+                    feature={feature}
+                    moveItem={moveItem} />
+            ))}
+        </StyledList>
+)}
 
 const StyledList = styled.ul`
     overflow: hidden;
     height: ${props => props.height};
     transition: .2s;
     display: flex;
+    flex-direction: column;
     flex-wrap: wrap;
 `;
-
-const calcHeight = (listLength) => {
-    const rows = Math.ceil(listLength / 2);
-    return rows * 34 + 'px';
-} 
-
-const FeatureList = ({ 
-    features, 
-    isOpen 
-}) => (
-    <StyledList height={isOpen ? calcHeight(features.length) : '0px'}>
-        {features.map(feature => (
-            <FeatureItem key={feature.id} 
-                feature={feature} />
-        ))}
-    </StyledList>
-)
 
 export default FeatureList;

--- a/src/features/SubsectionMenu/FeatureList.js
+++ b/src/features/SubsectionMenu/FeatureList.js
@@ -17,10 +17,14 @@ const calcHeight = (listLength) => {
     return rows * 34 + 'px';
 } 
 
-const FeatureList = ({ features, isOpen }) => (
+const FeatureList = ({ 
+    features, 
+    isOpen 
+}) => (
     <StyledList height={isOpen ? calcHeight(features.length) : '0px'}>
         {features.map(feature => (
-            <FeatureItem key={feature.id} feature={feature} />
+            <FeatureItem key={feature.id} 
+                feature={feature} />
         ))}
     </StyledList>
 )

--- a/src/features/SubsectionMenu/FeatureList.js
+++ b/src/features/SubsectionMenu/FeatureList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/macro';
+import { motion } from 'framer-motion';
 import { useDispatch } from 'react-redux'
 import { arrayMove } from 'utils'
 import { reorderFeatures } from 'dataSlice'
@@ -22,7 +23,8 @@ const FeatureList = ({
     }
 
     return (
-        <StyledList height={isOpen ? features.length * 34 + 'px' : '0px'}>
+        <StyledList variants={variants}
+            animate={isOpen ? 'open' : 'closed'}>
 
             {features.map((feature, i) => (
                 <FeatureItem i={i}
@@ -33,13 +35,22 @@ const FeatureList = ({
         </StyledList>
 )}
 
-const StyledList = styled.ul`
-    overflow: hidden;
-    height: ${props => props.height};
-    transition: .2s;
+const StyledList = styled(motion.ul)`
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
+    transform-origin: 50% 0;
 `;
+
+const variants = {
+    open: {
+        display: 'flex',
+        scaleY: 1
+    },
+    closed: {
+        scaleY: 0,
+        transitionEnd: { display: 'none' }
+    }
+}
 
 export default FeatureList;

--- a/src/features/SubsectionMenu/FeatureList.js
+++ b/src/features/SubsectionMenu/FeatureList.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 import { motion } from 'framer-motion';
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { arrayMove } from 'utils'
 import { reorderFeatures } from 'dataSlice'
+import { updateFeaturesOrderInDB } from 'utils'
 
 import FeatureItem from './FeatureItem';
 
@@ -15,6 +16,11 @@ const FeatureList = ({
     isOpen 
 }) => {
     const dispatch = useDispatch()
+    const isAdmin = useSelector(state => state.user?.isAdmin)
+
+    const updateOrderInDB = () => {
+        if (isAdmin) updateFeaturesOrderInDB(subsecID, ids)
+    }
 
     const moveItem = (current, target) => {
         const newOrder = arrayMove(ids, current, target);
@@ -30,7 +36,8 @@ const FeatureList = ({
                 <FeatureItem i={i}
                     key={feature.id} 
                     feature={feature}
-                    moveItem={moveItem} />
+                    moveItem={moveItem}
+                    updateOrderInDB={updateOrderInDB} />
             ))}
         </StyledList>
 )}

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -26,7 +26,8 @@ const FeatureMenu = ({
     i, 
     heights, 
     subsection, 
-    moveSubsection
+    moveSubsection,
+    scrollbar
 }) => {
     const [ featuresOpen, setFeaturesOpen ] = useState(false);
     const selectFeatures = useMemo(makeFeaturesSelector, []);
@@ -72,6 +73,10 @@ const FeatureMenu = ({
         if (dragged < -prev) {
             moveSubsection(i, i - 1)
         }
+
+        // scroll when dragging
+        scroll(scrollbar.current, info.delta.y, dragOriginY)
+
     }, [ i, moveSubsection ])
 
     return (
@@ -116,6 +121,19 @@ const FeatureMenu = ({
 
         </StyledFeatures>
     )
+}
+
+export const scroll = (scrollbar, y, dragOrigin) => {
+    scrollbar.scrollBy(0, y);
+
+    // adjust elem's position when scrolling
+    const scroll = scrollbar.scrollTop;
+    const scrollH = scrollbar.scrollHeight;
+    const clientH = scrollbar.clientHeight;
+
+    if (scroll > 0 && scroll < scrollH - clientH) {
+        dragOrigin.set(dragOrigin.get() + y)
+    }
 }
 
 

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -27,6 +27,7 @@ const FeatureMenu = ({ sub }) => {
     // array of features in the right order
     const features = useSelector(state => selectFeatures(state, sub.children));
 
+
     return (
         <StyledFeatures>
             <SubsectionLink 
@@ -36,7 +37,8 @@ const FeatureMenu = ({ sub }) => {
                 toggleFeatures={setFeaturesOpen}
                 featuresOpen={featuresOpen} />
 
-            <FeatureList 
+            <FeatureList subsecID={sub.id}
+                ids={sub.children}
                 features={features} 
                 isOpen={featuresOpen} />
         </StyledFeatures>
@@ -53,10 +55,6 @@ const StyledFeatures = styled.li`
 
     &:hover {
         background: var(--gray4);
-    }
-
-    a {
-        color: var(--white);
     }
 `;
 

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -22,12 +22,14 @@ const makeFeaturesSelector = () =>
 
 
 const StyledFeatures = styled.li`
-    background: var(--gray4);
-    margin-bottom: 3px;
+    background: var(--gray5);
+    border-radius: 3px;
+    border: 1px solid var(--gray5);
+    margin-bottom: 2px;
     transition: .2s;
 
     &:hover {
-        background: var(--gray3);
+        background: var(--gray4);
     }
 
     a {

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -6,19 +6,37 @@ import { createSelector } from '@reduxjs/toolkit';
 import SubsectionLink from './SubsectionLink';
 import FeatureList from './FeatureList';
 
-const makeFeaturesSelector = () => 
-    createSelector(
-        state => state.data.features,
-        (_, subsec) => subsec,
-        (features, subsec) => {
-            const featuresArr = Object.values(features);
-            return featuresArr.filter(feature => (
-                feature.sectionName === subsec.sectionName 
-                && 
-                feature.subsectionName === subsec.name
-            ))
-        }
+
+const makeFeaturesSelector = () => createSelector(
+    state => state.data.features,
+    (_, ids) => ids,
+
+    (features, ids) => ids.map(id => features[id])
+)
+
+
+const FeatureMenu = ({ sub }) => {
+    const [ featuresOpen, setFeaturesOpen ] = useState(false);
+    const featuresSelector = useMemo(makeFeaturesSelector, []);
+
+    // array of features
+    const features = useSelector(state => featuresSelector(state, sub.children));
+
+    return (
+        <StyledFeatures>
+            <SubsectionLink 
+                withToggler={features.length > 0}
+                to={`/${sub.sectionName}/${sub.name}`}
+                label={sub.name}
+                toggleFeatures={setFeaturesOpen}
+                featuresOpen={featuresOpen} />
+
+            <FeatureList 
+                features={features} 
+                isOpen={featuresOpen} />
+        </StyledFeatures>
     )
+}
 
 
 const StyledFeatures = styled.li`
@@ -37,22 +55,5 @@ const StyledFeatures = styled.li`
     }
 `;
 
-
-const FeatureMenu = ({ sub }) => {
-    const [ featuresOpen, setFeaturesOpen ] = useState(false);
-    const featuresSelector = useMemo(makeFeaturesSelector, []);
-    const features = useSelector(state => featuresSelector(state, sub))
-
-    return (
-        <StyledFeatures>
-            <SubsectionLink withToggler={features.length > 0}
-                        to={`/${sub.sectionName}/${sub.name}`}
-                        label={sub.name}
-                        toggleFeatures={setFeaturesOpen}
-                        featuresOpen={featuresOpen} />
-            <FeatureList features={features} isOpen={featuresOpen} />
-        </StyledFeatures>
-    )
-}
 
 export default FeatureMenu;

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -14,7 +14,7 @@ const makeFeaturesSelector = () => createSelector(
     (features, ids) => {
         // make sure the subsection with features finished fetching
         // otherwise, skip
-        if (!ids || !ids.length) return [];
+        if (!ids?.length) return [];
         return ids.map(id => features[id])
     }
 )

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -10,6 +10,10 @@ import SubsectionLink from './SubsectionLink';
 import FeatureList from './FeatureList';
 
 
+// this component is way too big and messy
+// probably need to extract smth
+// not sure what though
+
 const makeFeaturesSelector = () => createSelector(
     state => state.data.features,
     (_, ids) => ids,
@@ -28,29 +32,22 @@ const FeatureMenu = ({
     heights, 
     subsection, 
     moveSubsection,
-    scrollbar
+    scrollbar,
+    updateOrderInDB
 }) => {
-    const [ featuresOpen, setFeaturesOpen ] = useState(false);
-    const selectFeatures = useMemo(makeFeaturesSelector, []);
+    const [ featuresOpen, setFeaturesOpen ] = useState(false)
+    const [ isDragging, setDragging ] = useState(false)
+    const dragOriginY = useMotionValue(0)
+    const selectFeatures = useMemo(makeFeaturesSelector, [])
+
+    const { name, id, sectionName, children: featuresIDs } = subsection
 
     // set the item's current height, so the siblings can know it
     heights.current[i] = featuresOpen ? 
-        47 + subsection.children.length * 32 : 47
-
-
-    const { 
-        name, 
-        id, 
-        sectionName, 
-        children: featuresIDs
-    } = subsection
+        47 + featuresIDs.length * 32 : 47
 
     // array of features in the right order
     const features = useSelector(state => selectFeatures(state, featuresIDs));
-
-    const [ isDragging, setDragging ] = useState(false)
-
-    const dragOriginY = useMotionValue(0);
 
     // dragging starts onMouseDown on a nested component (SubsectionLink)
     const dragControls = useDragControls();
@@ -97,7 +94,10 @@ const FeatureMenu = ({
 
             onDrag={onDrag}
             onDragStart={() => setDragging(true)}
-            onDragEnd={() => setDragging(false)}
+            onDragEnd={() => {
+                setDragging(false)
+                updateOrderInDB()
+            }}
             
             positionTransition={({ delta }) => {
                 if (isDragging) dragOriginY.set(dragOriginY.get() + delta.y)

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -11,16 +11,21 @@ const makeFeaturesSelector = () => createSelector(
     state => state.data.features,
     (_, ids) => ids,
 
-    (features, ids) => ids.map(id => features[id])
+    (features, ids) => {
+        // make sure the subsection with features finished fetching
+        // otherwise, skip
+        if (!ids || !ids.length) return [];
+        return ids.map(id => features[id])
+    }
 )
 
 
 const FeatureMenu = ({ sub }) => {
     const [ featuresOpen, setFeaturesOpen ] = useState(false);
-    const featuresSelector = useMemo(makeFeaturesSelector, []);
+    const selectFeatures = useMemo(makeFeaturesSelector, []);
 
-    // array of features
-    const features = useSelector(state => featuresSelector(state, sub.children));
+    // array of features in the right order
+    const features = useSelector(state => selectFeatures(state, sub.children));
 
     return (
         <StyledFeatures>

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -3,6 +3,7 @@ import styled from 'styled-components/macro';
 import { useSelector } from 'react-redux';
 import { createSelector } from '@reduxjs/toolkit';
 import { motion, useMotionValue, useDragControls } from 'framer-motion'
+import { scroll } from 'utils'
 
 
 import SubsectionLink from './SubsectionLink';
@@ -121,19 +122,6 @@ const FeatureMenu = ({
 
         </StyledFeatures>
     )
-}
-
-export const scroll = (scrollbar, y, dragOrigin) => {
-    scrollbar.scrollBy(0, y);
-
-    // adjust elem's position when scrolling
-    const scroll = scrollbar.scrollTop;
-    const scrollH = scrollbar.scrollHeight;
-    const clientH = scrollbar.clientHeight;
-
-    if (scroll > 0 && scroll < scrollH - clientH) {
-        dragOrigin.set(dragOrigin.get() + y)
-    }
 }
 
 

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -8,7 +8,7 @@ import FeatureList from './FeatureList';
 
 const makeFeaturesSelector = () => 
     createSelector(
-        state => state.data.features.byID,
+        state => state.data.features,
         (_, subsec) => subsec,
         (features, subsec) => {
             const featuresArr = Object.values(features);

--- a/src/features/SubsectionMenu/SubsectionLink.js
+++ b/src/features/SubsectionMenu/SubsectionLink.js
@@ -1,18 +1,56 @@
 import React from 'react';
 import styled from 'styled-components/macro';
+import { motion, useMotionValue } from 'framer-motion';
+
 import { NavLink } from 'react-router-dom';
 
-const StyledSub = styled.div`
+
+const SubsectionLink = ({ 
+    to, 
+    label, 
+    withToggler, 
+    featuresOpen, 
+    toggleFeatures,
+    startDrag,
+    isDragging
+}) => {
+    return (
+        <StyledSub isDragging={isDragging}>
+
+            <NavLink to={to} 
+                activeClassName='active'
+                onMouseDown={startDrag}>
+                {label}
+            </NavLink>
+
+            {withToggler && (
+                <StyledToggler 
+                    rotate={featuresOpen ? '180deg' : '0deg'} 
+                    className="fas fa-angle-up"
+                    onClick={() => toggleFeatures(!featuresOpen)} 
+                />
+            )}
+        </StyledSub>
+)}
+
+
+const StyledSub = styled(motion.div)`
     position: relative;
     text-align: left;
 
     a {
-        padding: 10px;
-        padding-left: 16px;
+        color: var(--gray1);
+        background: ${props => props.isDragging ? 'var(--gray4)' : 'var(--gray5)'};
+        padding: 12px;
+        padding-left: 22px;
         display: block;
         height: 100%;
         font-size: 1.4rem;
         transition: .2s;
+    }
+
+    a:hover {
+        background: var(--gray4);
     }
 
     a.active {
@@ -37,21 +75,5 @@ const StyledToggler = styled.i`
     }
 `;
 
-
-const SubsectionLink = ({ to, label, withToggler, featuresOpen, toggleFeatures }) => (
-    <StyledSub>
-        <NavLink to={to} activeClassName='active'>
-            {label}
-        </NavLink>
-
-        {withToggler && (
-            <StyledToggler 
-                rotate={featuresOpen ? '180deg' : '0deg'} 
-                className="fas fa-angle-up"
-                onClick={() => toggleFeatures(!featuresOpen)} 
-            />
-        )}
-    </StyledSub>
-)
 
 export default SubsectionLink;

--- a/src/features/SubsectionMenu/SubsectionLink.js
+++ b/src/features/SubsectionMenu/SubsectionLink.js
@@ -16,7 +16,8 @@ const StyledSub = styled.div`
     }
 
     a.active {
-        background: var(--gray3);
+        background: var(--gray4);
+        color: var(--orange2);
     }
 `;
 
@@ -32,8 +33,7 @@ const StyledToggler = styled.i`
     cursor: pointer;
 
     &:hover {
-        border: 1px solid var(--gray2);
-        box-shadow: 0 0 3px 0 var(--black);     
+        color: var(--orange2);
     }
 `;
 

--- a/src/features/SubsectionMenu/SubsectionMenu.js
+++ b/src/features/SubsectionMenu/SubsectionMenu.js
@@ -2,13 +2,13 @@ import React, { useRef } from 'react';
 import styled from 'styled-components/macro';
 import { useDispatch } from 'react-redux';
 import { reorderSubsections } from 'dataSlice';
-import { arrayMove } from 'utils'
+import { arrayMove, updateSubsectionsOrderInDB } from 'utils'
 
 import FeatureMenu from './FeatureMenu';
 
 
 
-const SubsectionMenu = ({ items, ids }) => {
+const SubsectionMenu = ({ items, ids, isAdmin }) => {
     const dispatch = useDispatch();
     const scrollbar = useRef();
 
@@ -18,6 +18,11 @@ const SubsectionMenu = ({ items, ids }) => {
         const newOrder = arrayMove(ids, current, target);
         if (ids === newOrder) return;
         dispatch(reorderSubsections({ sectionID, newOrder }));
+    }
+
+    // update DB onDragEnd (subsections)
+    const updateOrderInDB = () => {
+        if (isAdmin) updateSubsectionsOrderInDB(items[0].sectionID, ids)
     }
 
     // sort items in the id's order
@@ -41,7 +46,8 @@ const SubsectionMenu = ({ items, ids }) => {
                     key={item.id} 
                     subsection={item}
                     moveSubsection={moveSubsection}
-                    scrollbar={scrollbar} />
+                    scrollbar={scrollbar}
+                    updateOrderInDB={updateOrderInDB} />
             ))}
         </Ul>
     )

--- a/src/features/SubsectionMenu/SubsectionMenu.js
+++ b/src/features/SubsectionMenu/SubsectionMenu.js
@@ -26,6 +26,10 @@ const StyledMenu = styled.section`
     flex-basis: 250px;
     text-align: center;
     padding: 4px;
+
+    .subs {
+        padding-right: 12px;
+    }
 `;
 
 
@@ -51,7 +55,7 @@ const SubsectionMenu = () => {
     return (
         <StyledMenu>
             <Scrollbar>
-                <ul>
+                <ul className='subs'>
                     {subsections.map(sub => (
                         <FeatureMenu key={sub.id} sub={sub} />
                     ))}

--- a/src/features/SubsectionMenu/SubsectionMenu.js
+++ b/src/features/SubsectionMenu/SubsectionMenu.js
@@ -11,7 +11,7 @@ import FeatureMenu from './FeatureMenu';
 
 
 const selectSubsections = createSelector(
-    state => state.data.subsections.byID,
+    state => state.data.subsections,
     (_, sectionName) => sectionName,
     (subs, sectionName) => {
         const subsArr = Object.values(subs)

--- a/src/features/SubsectionMenu/SubsectionMenu.js
+++ b/src/features/SubsectionMenu/SubsectionMenu.js
@@ -1,18 +1,45 @@
-import React from 'react';
+import React, { useRef, useCallback } from 'react';
 import styled from 'styled-components/macro';
+import { useDispatch } from 'react-redux';
+import { reorderSubsections } from 'dataSlice';
+import { arrayMove } from 'utils'
 
 import Scrollbar from 'components/Scrollbar';
 import FeatureMenu from './FeatureMenu';
 
 
 
-const SubsectionMenu = ({ subs }) => {
+const SubsectionMenu = ({ items, ids }) => {
+    const dispatch = useDispatch();
+
+    // swap subsections when dragging
+    const moveSubsection = (current, target) => {
+        const sectionID = items[0].sectionID;
+        const newOrder = arrayMove(ids, current, target);
+        if (ids === newOrder) return;
+        dispatch(reorderSubsections({ sectionID, newOrder }));
+    }
+
+    // sort items in the id's order
+    const sortedItems = ids.map(id => {
+        return items.find(i => i.id === id)
+    })
+
+    // feature menus' heights vary as the user toggles open/close
+    // we need to collect all menu's current heights in an array
+    // this way each FeatureMenu will know the height of the prev/next item
+    // so it can know when to swap positions when dragging
+    const heights = useRef([])
     
     return (
         <Scrollbar>
             <Ul className='subs'>
-                {subs.map(sub => (
-                    <FeatureMenu key={sub.id} sub={sub} />
+                {sortedItems.map((item, i) => (
+                    <FeatureMenu i={i}
+                        heights={heights}
+                        key={item.id} 
+                        subsection={item}
+                        moveSubsection={moveSubsection} />
                 ))}
             </Ul>
         </Scrollbar>
@@ -21,7 +48,6 @@ const SubsectionMenu = ({ subs }) => {
 
 
 const Ul = styled.ul`
-    padding-right: 12px;
 `;
 
 export default SubsectionMenu;

--- a/src/features/SubsectionMenu/SubsectionMenu.js
+++ b/src/features/SubsectionMenu/SubsectionMenu.js
@@ -7,7 +7,7 @@ import FeatureMenu from './FeatureMenu';
 
 
 const SubsectionMenu = ({ subs }) => {
-
+    
     return (
         <Scrollbar>
             <Ul className='subs'>

--- a/src/features/SubsectionMenu/SubsectionMenu.js
+++ b/src/features/SubsectionMenu/SubsectionMenu.js
@@ -12,12 +12,61 @@ import FeatureMenu from './FeatureMenu';
 
 const selectSubsections = createSelector(
     state => state.data.subsections,
-    (_, sectionName) => sectionName,
-    (subs, sectionName) => {
+    (_, secName) => secName,
+    (subs, secName) => {
+        if (!secName) return [];
         const subsArr = Object.values(subs)
-        return subsArr.filter(sub => sub.sectionName === sectionName)
+        return subsArr.filter(sub => sub.sectionName === secName)
     }
 )
+
+const selectIDs = createSelector(
+    state => state.data.sections.byID,
+    (_, secName) => secName,
+    (sections, secName) => {
+        if (!secName) return [];
+        const secsArr = Object.values(sections);
+        const sec = secsArr.filter(sec => sec.name === secName)[0];
+        return sec.children;
+    }
+    
+)
+
+
+const SubsectionMenu = () => {
+    let { sectionName } = useParams();
+    const dispatch = useDispatch();
+
+    // array of subsections
+    const subsecs = useSelector(state => selectSubsections(state, sectionName))
+
+    // array of subsections' ids to render the subsecs in the correct order
+    const ids = useSelector(state => selectIDs(state, sectionName))
+
+    useEffect(() => {
+        // if subsections were fetched before, return
+        if (!sectionName || subsecs.length) return;
+        dispatch(getSubsections(sectionName));
+    }, [sectionName])
+
+    if (!sectionName || !subsecs.length) return (
+        <StyledMenu>
+            <Spinner />
+        </StyledMenu>
+    )
+
+    return (
+        <StyledMenu>
+            <Scrollbar>
+                <ul className='subs'>
+                    {ids.map(id => (
+                        <FeatureMenu key={id} sub={subsecs[id]} />
+                    ))}
+                </ul>
+            </Scrollbar>
+        </StyledMenu>
+    )
+}
 
 
 const StyledMenu = styled.section`
@@ -31,38 +80,5 @@ const StyledMenu = styled.section`
         padding-right: 12px;
     }
 `;
-
-
-const SubsectionMenu = () => {
-    let { sectionName } = useParams();
-    sectionName = sectionName || 'JavaScript';
-    const dispatch = useDispatch();
-
-    const subsections = useSelector(state => selectSubsections(state, sectionName))
-
-    useEffect(() => {
-        // if subsections were fetched before, return
-        if (subsections.length) return;
-        dispatch(getSubsections(sectionName));
-    }, [sectionName])
-
-    if (!subsections.length) return (
-        <StyledMenu>
-            <Spinner />
-        </StyledMenu>
-    )
-
-    return (
-        <StyledMenu>
-            <Scrollbar>
-                <ul className='subs'>
-                    {subsections.map(sub => (
-                        <FeatureMenu key={sub.id} sub={sub} />
-                    ))}
-                </ul>
-            </Scrollbar>
-        </StyledMenu>
-    )
-}
 
 export default SubsectionMenu;

--- a/src/features/SubsectionMenu/SubsectionMenu.js
+++ b/src/features/SubsectionMenu/SubsectionMenu.js
@@ -1,89 +1,27 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components/macro';
-import { useParams } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
-import { createSelector } from 'reselect';
-import { getSubsections } from '../../dataSlice';
 
-import Spinner from 'components/Spinner';
 import Scrollbar from 'components/Scrollbar';
 import FeatureMenu from './FeatureMenu';
 
 
 
-const selectIDs = createSelector(
-    state => state.data.sections.byID,
-    (state, secName) => secName,
-
-    (sections, secName) => {
-        if (!secName) return []
-        const secsArr = Object.values(sections)
-        // if sections hasn't finished fetching yet, skip
-        if (!secsArr.length) return [];
-
-        const sec = secsArr.filter(sec => sec.name === secName)[0]
-        return sec.children
-    }
-)
-
-const selectAndSortSubsecs = createSelector(
-    state => state.data.subsections,
-    (state, secName) => selectIDs(state, secName),
-
-    (subs, ids) => {
-        // if either secs or subsecs
-        // hasn't finished fetching yet, skip
-        if (!ids.length || !Object.keys(subs).length) return [];
-
-        return ids.map(id => subs[id])
-    }
-)
-
-
-const SubsectionMenu = () => {
-    let { sectionName } = useParams();
-    const dispatch = useDispatch();
-
-    // array of subsections in the right order
-    const subsecs = useSelector(state => selectAndSortSubsecs(state, sectionName))
-
-    // fetch subsections and features whenever the url changes
-    useEffect(() => {
-        if (!sectionName || subsecs.length) return;
-        dispatch(getSubsections(sectionName));
-    }, [sectionName])
-
-    // wait for the fetching to complete
-    if (!sectionName || !subsecs.length) return (
-        <StyledMenu>
-            <Spinner />
-        </StyledMenu>
-    )
+const SubsectionMenu = ({ subs }) => {
 
     return (
-        <StyledMenu>
-            <Scrollbar>
-                <ul className='subs'>
-                    {subsecs.map(sub => (
-                        <FeatureMenu key={sub.id} sub={sub} />
-                    ))}
-                </ul>
-            </Scrollbar>
-        </StyledMenu>
+        <Scrollbar>
+            <Ul className='subs'>
+                {subs.map(sub => (
+                    <FeatureMenu key={sub.id} sub={sub} />
+                ))}
+            </Ul>
+        </Scrollbar>
     )
 }
 
 
-const StyledMenu = styled.section`
-    height: 100%;
-    background: var(--gray6);
-    flex-basis: 250px;
-    text-align: center;
-    padding: 4px;
-
-    .subs {
-        padding-right: 12px;
-    }
+const Ul = styled.ul`
+    padding-right: 12px;
 `;
 
 export default SubsectionMenu;

--- a/src/features/SubsectionMenu/SubsectionMenu.js
+++ b/src/features/SubsectionMenu/SubsectionMenu.js
@@ -1,16 +1,16 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components/macro';
 import { useDispatch } from 'react-redux';
 import { reorderSubsections } from 'dataSlice';
 import { arrayMove } from 'utils'
 
-import Scrollbar from 'components/Scrollbar';
 import FeatureMenu from './FeatureMenu';
 
 
 
 const SubsectionMenu = ({ items, ids }) => {
     const dispatch = useDispatch();
+    const scrollbar = useRef();
 
     // swap subsections when dragging
     const moveSubsection = (current, target) => {
@@ -32,17 +32,18 @@ const SubsectionMenu = ({ items, ids }) => {
     const heights = useRef([])
     
     return (
-        <Scrollbar>
-            <Ul className='subs'>
-                {sortedItems.map((item, i) => (
-                    <FeatureMenu i={i}
-                        heights={heights}
-                        key={item.id} 
-                        subsection={item}
-                        moveSubsection={moveSubsection} />
-                ))}
-            </Ul>
-        </Scrollbar>
+        <Ul className='scrollbar'
+            ref={scrollbar}>
+
+            {sortedItems.map((item, i) => (
+                <FeatureMenu i={i}
+                    heights={heights}
+                    key={item.id} 
+                    subsection={item}
+                    moveSubsection={moveSubsection}
+                    scrollbar={scrollbar} />
+            ))}
+        </Ul>
     )
 }
 

--- a/src/features/SubsectionMenu/SubsectionsContainer.js
+++ b/src/features/SubsectionMenu/SubsectionsContainer.js
@@ -43,6 +43,8 @@ const SubsectionsContainer = () => {
     let { sectionName } = useParams();
     const dispatch = useDispatch();
 
+    const isAdmin = useSelector(state => state.user?.isAdmin)
+
     // array of subsections
     const subsecs = useSelector(state => selectSubsections(state, sectionName))
 
@@ -62,6 +64,7 @@ const SubsectionsContainer = () => {
                 <Spinner /> 
                 : 
                 <SubsectionMenu 
+                    isAdmin={isAdmin}
                     items={subsecs} 
                     ids={ids} />
             }

--- a/src/features/SubsectionMenu/SubsectionsContainer.js
+++ b/src/features/SubsectionMenu/SubsectionsContainer.js
@@ -9,21 +9,16 @@ import SubsectionMenu from './SubsectionMenu'
 import Spinner from 'components/Spinner'
 
 
-// returns an object of subsections
-const selectSubs = createSelector(
+// returns an array of subsections
+const selectSubsections = createSelector(
     state => state.data.subsections,
     (state, secName) => secName,
 
     (subs, secName) => {
-        const result = {}
-        if (!secName) return result
-        for (let i in subs) {
-            const sub = subs[i]
-            if (sub.sectionName === secName) {
-                result[sub.id] = sub
-            }
-        }
-        return result
+        const subsArr = Object.values(subs)
+            .filter(sub => sub.sectionName === secName)
+        
+        return subsArr
     }
 )
 
@@ -43,24 +38,16 @@ const selectIDs = createSelector(
     }
 )
 
-const selectAndSortSubsecs = createSelector(
-    selectSubs,
-    selectIDs,
-
-    (subs, ids) => {
-        const subsArr = Object.keys(subs)
-        if (!subsArr.length) return []
-        return ids.map(id => subs[id])
-    }
-)
-
 
 const SubsectionsContainer = () => {
     let { sectionName } = useParams();
     const dispatch = useDispatch();
 
-    // array of subsections in the right order
-    const subsecs = useSelector(state => selectAndSortSubsecs(state, sectionName))
+    // array of subsections
+    const subsecs = useSelector(state => selectSubsections(state, sectionName))
+
+    // array of subsec's ids in the right order
+    const ids = useSelector(state => selectIDs(state, sectionName))
 
     // fetch subsections and features whenever the url changes
     useEffect(() => {
@@ -74,7 +61,9 @@ const SubsectionsContainer = () => {
             {!sectionName || !subsecs.length ? 
                 <Spinner /> 
                 : 
-                <SubsectionMenu subs={subsecs} />
+                <SubsectionMenu 
+                    items={subsecs} 
+                    ids={ids} />
             }
         </StyledMenu>
     )
@@ -86,11 +75,7 @@ const StyledMenu = styled.section`
     background: var(--gray6);
     flex-basis: 250px;
     text-align: center;
-    padding: 4px;
-
-    .subs {
-        padding-right: 12px;
-    }
+    padding: 7px;
 `;
 
 

--- a/src/features/SubsectionMenu/SubsectionsContainer.js
+++ b/src/features/SubsectionMenu/SubsectionsContainer.js
@@ -9,30 +9,47 @@ import SubsectionMenu from './SubsectionMenu'
 import Spinner from 'components/Spinner'
 
 
+// returns an object of subsections
+const selectSubs = createSelector(
+    state => state.data.subsections,
+    (state, secName) => secName,
+
+    (subs, secName) => {
+        const result = {}
+        if (!secName) return result
+        for (let i in subs) {
+            const sub = subs[i]
+            if (sub.sectionName === secName) {
+                result[sub.id] = sub
+            }
+        }
+        return result
+    }
+)
+
+// returns section.children - an array of subsections' ids
 const selectIDs = createSelector(
     state => state.data.sections.byID,
     (state, secName) => secName,
 
     (sections, secName) => {
-        if (!secName) return []
         const secsArr = Object.values(sections)
         // if sections hasn't finished fetching yet, skip
-        if (!secsArr.length) return [];
+        if (!secName || !secsArr.length) return []
 
         const sec = secsArr.filter(sec => sec.name === secName)[0]
+        if (!sec) return []
         return sec.children
     }
 )
 
 const selectAndSortSubsecs = createSelector(
-    state => state.data.subsections,
-    (state, secName) => selectIDs(state, secName),
+    selectSubs,
+    selectIDs,
 
     (subs, ids) => {
-        // if either secs or subsecs
-        // hasn't finished fetching yet, skip
-        if (!ids.length || !Object.keys(subs).length) return [];
-
+        const subsArr = Object.keys(subs)
+        if (!subsArr.length) return []
         return ids.map(id => subs[id])
     }
 )
@@ -55,7 +72,9 @@ const SubsectionsContainer = () => {
     return (
         <StyledMenu>
             {!sectionName || !subsecs.length ? 
-                <Spinner /> : <SubsectionMenu subs={subsecs} />
+                <Spinner /> 
+                : 
+                <SubsectionMenu subs={subsecs} />
             }
         </StyledMenu>
     )

--- a/src/features/SubsectionMenu/SubsectionsContainer.js
+++ b/src/features/SubsectionMenu/SubsectionsContainer.js
@@ -1,0 +1,78 @@
+import React, { useEffect } from 'react'
+import styled from 'styled-components/macro'
+import { useParams } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { createSelector } from 'reselect';
+import { getSubsections } from '../../dataSlice';
+
+import SubsectionMenu from './SubsectionMenu'
+import Spinner from 'components/Spinner'
+
+
+const selectIDs = createSelector(
+    state => state.data.sections.byID,
+    (state, secName) => secName,
+
+    (sections, secName) => {
+        if (!secName) return []
+        const secsArr = Object.values(sections)
+        // if sections hasn't finished fetching yet, skip
+        if (!secsArr.length) return [];
+
+        const sec = secsArr.filter(sec => sec.name === secName)[0]
+        return sec.children
+    }
+)
+
+const selectAndSortSubsecs = createSelector(
+    state => state.data.subsections,
+    (state, secName) => selectIDs(state, secName),
+
+    (subs, ids) => {
+        // if either secs or subsecs
+        // hasn't finished fetching yet, skip
+        if (!ids.length || !Object.keys(subs).length) return [];
+
+        return ids.map(id => subs[id])
+    }
+)
+
+
+const SubsectionsContainer = () => {
+    let { sectionName } = useParams();
+    const dispatch = useDispatch();
+
+    // array of subsections in the right order
+    const subsecs = useSelector(state => selectAndSortSubsecs(state, sectionName))
+
+    // fetch subsections and features whenever the url changes
+    useEffect(() => {
+        if (!sectionName || subsecs.length) return;
+        dispatch(getSubsections(sectionName));
+    }, [sectionName])
+
+
+    return (
+        <StyledMenu>
+            {!sectionName || !subsecs.length ? 
+                <Spinner /> : <SubsectionMenu subs={subsecs} />
+            }
+        </StyledMenu>
+    )
+}
+
+
+const StyledMenu = styled.section`
+    height: 100%;
+    background: var(--gray6);
+    flex-basis: 250px;
+    text-align: center;
+    padding: 4px;
+
+    .subs {
+        padding-right: 12px;
+    }
+`;
+
+
+export default SubsectionsContainer;

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -68,3 +68,9 @@ export const createContentItem = async (id, name, url) => {
     await db.collection('content').doc(id).set(item);
     return item;
 }
+
+
+export const updateSectionsOrderInDB = ids => {
+    db.doc('order/sections')
+        .update({ ids })
+}

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -77,10 +77,10 @@ export const updateSectionsOrderInDB = ids => {
 
 export const updateSubsectionsOrderInDB = (sectionID, newOrder) => {
     db.doc(`sections/${sectionID}`)
-        .update({ newOrder })
+        .update({ children: newOrder })
 }
 
 export const updateFeaturesOrderInDB = (subsecID, newOrder) => {
     db.doc(`subsections/${subsecID}`)
-        .update({ newOrder })
+        .update({ children: newOrder })
 }

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -74,3 +74,13 @@ export const updateSectionsOrderInDB = ids => {
     db.doc('order/sections')
         .update({ ids })
 }
+
+export const updateSubsectionsOrderInDB = (sectionID, newOrder) => {
+    db.doc(`sections/${sectionID}`)
+        .update({ newOrder })
+}
+
+export const updateFeaturesOrderInDB = (subsecID, newOrder) => {
+    db.doc(`subsections/${subsecID}`)
+        .update({ newOrder })
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -31,3 +31,10 @@ export const scroll = (scrollbar, y, dragOrigin) => {
         dragOrigin.set(dragOrigin.get() + y)
     }
 }
+
+
+export {
+    updateSectionsOrderInDB,
+    updateSubsectionsOrderInDB,
+    updateFeaturesOrderInDB,
+} from './db'

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,17 @@
+
+
+// takes an array, current and target indexex of an item, 
+// moves the item from current to target index
+// returns a new array
+export const arrayMove = (arr, current, target) => {
+    if (target < 0 || target > arr.length - 1) return;
+
+    const newArr = [...arr];
+
+    // delete the elem from the ids array
+    const el = newArr.splice(current, 1)[0];
+    // and insert it in the target position
+    newArr.splice(target, 0, el);
+    
+    return newArr
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,7 +4,7 @@
 // moves the item from current to target index
 // returns a new array
 export const arrayMove = (arr, current, target) => {
-    if (target < 0 || target > arr.length - 1) return;
+    if (target < 0 || target > arr.length - 1) return arr;
 
     const newArr = [...arr];
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -15,3 +15,19 @@ export const arrayMove = (arr, current, target) => {
     
     return newArr
 }
+
+
+// takes a scrollbar elem, value to scroll by, 
+// and dragOrigin to update the dragged elem's position while scrolling
+export const scroll = (scrollbar, y, dragOrigin) => {
+    scrollbar.scrollBy(0, y);
+
+    // adjust elem's position when scrolling
+    const scroll = scrollbar.scrollTop;
+    const scrollH = scrollbar.scrollHeight;
+    const clientH = scrollbar.clientHeight;
+
+    if (scroll > 0 && scroll < scrollH - clientH) {
+        dragOrigin.set(dragOrigin.get() + y)
+    }
+}


### PR DESCRIPTION
Now sections, subsections and features can be reordered with drag'n'drop.
(only within their lists)

Note that although even a guest can reorder the items, the new order is saved in the db only when the admin does it.

closes #1 