### PR TITLE
Issues#8 fix

### DIFF
--- a/src/features/SectionMenu/SectionLink.js
+++ b/src/features/SectionMenu/SectionLink.js
@@ -18,6 +18,9 @@ const SectionLink = ({
     const elemRef = useRef();
     const dragOriginY = useMotionValue(0);
 
+    // set dragged onDragEnd
+    const [ dragged, setDragged ] = useState(false);
+
     const isOnTop = () => {
         const el = elemRef.current.getBoundingClientRect();
         const ulTop = ul.current.getBoundingClientRect().top;
@@ -61,6 +64,11 @@ const SectionLink = ({
             }}
 
             onDragEnd={() => {
+                // prevent clicks
+                // see NavLink onClick below
+                setDragged(true);
+                setTimeout(() => setDragged(false), 50)
+
                 setDragging(false);
                 updateDB();
             }}
@@ -73,8 +81,12 @@ const SectionLink = ({
             }}
         >
 
-            <NavLink to={`/${label}`} activeClassName='active'>
-                {label}
+            <NavLink to={`/${label}`} 
+                activeClassName='active'
+                onClick={e => {
+                    if (dragged) e.preventDefault()
+                }}>
+                    {label}
             </NavLink>
 
         </StyledLink>

--- a/src/features/SubsectionMenu/FeatureItem.js
+++ b/src/features/SubsectionMenu/FeatureItem.js
@@ -13,6 +13,8 @@ const FeatureItem = ({
     const [ isDragging, setDragging ] = useState(false)
     const dragOriginY = useMotionValue(0);
 
+    const [ dragged, setDragged ] = useState(false)
+
     const { name, sectionName, subsectionName } = feature;
 
     return (
@@ -32,6 +34,11 @@ const FeatureItem = ({
 
             onDragStart={() => setDragging(true)}
             onDragEnd={() => {
+                // prevent url transitions after drag end
+                // see NavLink's onClick below
+                setDragged(true)
+                setTimeout(() => setDragged(false), 50)
+
                 setDragging(false)
                 updateOrderInDB()
             }}
@@ -44,7 +51,10 @@ const FeatureItem = ({
             }} >
 
             <NavLink activeClassName='active'
-                to={`/${sectionName}/${subsectionName}/${name}`} >
+                to={`/${sectionName}/${subsectionName}/${name}`}
+                onClick={e => {
+                    if (dragged) e.preventDefault()
+                }} >
                     {name}
             </NavLink>
         </StyledItem>

--- a/src/features/SubsectionMenu/FeatureMenu.js
+++ b/src/features/SubsectionMenu/FeatureMenu.js
@@ -21,6 +21,9 @@ const FeatureMenu = ({
     const [ isDragging, setDragging ] = useState(false)
     const dragOriginY = useMotionValue(0)
 
+    // set dragged onDragEnd
+    const [ dragged, setDragged ] = useState(false)
+
     const { name, id, sectionName, children: featuresIDs } = subsection
 
     // set the item's current height, so the siblings can know it
@@ -70,6 +73,11 @@ const FeatureMenu = ({
             onDrag={onDrag}
             onDragStart={() => setDragging(true)}
             onDragEnd={() => {
+                // prevent url redirections onDragEnd
+                // see SubsectionLink onClick
+                setDragged(true)
+                setTimeout(() => setDragged(false), 50)
+
                 setDragging(false)
                 updateOrderInDB()
             }}
@@ -82,6 +90,9 @@ const FeatureMenu = ({
             }} >
 
             <SubsectionLink 
+                onClick={e => {
+                    if (dragged) e.preventDefault()
+                }}
                 withToggler={featuresIDs.length > 0}
                 to={`/${sectionName}/${name}`}
                 label={name}

--- a/src/features/SubsectionMenu/SubsectionLink.js
+++ b/src/features/SubsectionMenu/SubsectionLink.js
@@ -8,6 +8,7 @@ import { NavLink } from 'react-router-dom';
 const SubsectionLink = ({ 
     to, 
     label, 
+    onClick,
     withToggler, 
     featuresOpen, 
     toggleFeatures,
@@ -19,6 +20,7 @@ const SubsectionLink = ({
 
             <NavLink to={to} 
                 activeClassName='active'
+                onClick={onClick}
                 onMouseDown={startDrag}>
                 {label}
             </NavLink>


### PR DESCRIPTION
This pr fixes the mentioned bug by: 

- creating a state variable in a draggable component, initializing it with false value 
- setting it to true onDragEnd
- immediately setting a timeout to set it back to false after 50ms
- assigning onClick to a link with a preventDefault call if dragged is true

Although this solution works, it doesn't feel right. Instead of assigning an onClick to a link, i'd rather prevent clicks from bubbling down to it.

https://github.com/facebook/react/issues/5625
https://stackoverflow.com/questions/24415631/reactjs-syntheticevent-stoppropagation-only-works-with-react-events

This didn't work:
```js
onClickCapture={e => 
    if (dragged) {
        e.stopPropagation()
        e.nativeEvent.stopImmediatePropagation()
    }
}
```
It prevents the react-router's NavLink from redirecting, but the default behavior is still there - it redirects with a page reload.

fixes #8 