### PR TITLE
bugFix/15

### DIFF
--- a/src/features/Content/ContentEditor.js
+++ b/src/features/Content/ContentEditor.js
@@ -39,7 +39,9 @@ const ContentEditor = ({ content, updateContent }) => {
                     // must nullify the selection when quitting editing
                     // to prevent HoveringMenu from re-appearing at the same place
                     // when the user will start editing again
+                    console.log(editor.selection)
                     if (!readOnly) editor.selection = null
+                    console.log(editor.selection)
                     setReadOnly(!readOnly)
                 }} 
             />

--- a/src/features/Content/editor/commands.js
+++ b/src/features/Content/editor/commands.js
@@ -52,27 +52,35 @@ export const setMark = (editor, mark, value, selection) => {
 }
 
 
-
+// focuses the editor
 // inserts an elem with the given type at the current selection
 // if there's no selection, inserts at the end of the doc
-// focuses the editor
 
 export const insertElem = (editor, type) => {
     ReactEditor.focus(editor)
 
+    // we don't want to insert the elem between the title and the links panel
+    // nor to split the title and insert it between
+
+    // if the selection is inside the title
+    // specify the explicit location where to insert the elem
+    // and that would be right after the links panel
+
+    const insertAt = isInside(editor, 'title') ? [2] : null
+
     if (type === 'ul') {
-        insertUl(editor)
+        insertUl(editor, insertAt)
         return
     }
 
     Transforms.insertNodes(editor, {
         type,
         children: [{ text: `[ ${type} ]` }]
-    })
+    }, { at: insertAt })
 }
 
 
-const insertUl = editor => {
+const insertUl = (editor, insertAt) => {
     const li = { 
         type: 'li', 
         children: [{ text: '[ list-item ]'}] 
@@ -81,7 +89,7 @@ const insertUl = editor => {
         type: 'ul',
     }
 
-    Transforms.insertNodes(editor, li)
+    Transforms.insertNodes(editor, li, { at: insertAt })
     Transforms.wrapNodes(editor, ul)
 }
 

--- a/src/features/Content/editor/commands.js
+++ b/src/features/Content/editor/commands.js
@@ -73,10 +73,12 @@ export const insertElem = (editor, type) => {
         return
     }
 
-    Transforms.insertNodes(editor, {
+    const elem = {
         type,
         children: [{ text: `[ ${type} ]` }]
-    }, { at: insertAt })
+    }
+
+    Transforms.insertNodes(editor, elem, { at: insertAt })
 }
 
 
@@ -85,12 +87,10 @@ const insertUl = (editor, insertAt) => {
         type: 'li', 
         children: [{ text: '[ list-item ]'}] 
     }
-    const ul ={
-        type: 'ul',
-    }
+    const ul = { type: 'ul' }
 
     Transforms.insertNodes(editor, li, { at: insertAt })
-    Transforms.wrapNodes(editor, ul)
+    Transforms.wrapNodes(editor, ul, { at: insertAt })
 }
 
 

--- a/src/features/Content/editor/createEditor.js
+++ b/src/features/Content/editor/createEditor.js
@@ -40,7 +40,7 @@ const withNormalizing = editor => {
             for (const [child] of children) {
                 if (child.type !== 'li') {
                     Transforms.liftNodes(editor)
-                    return;
+                    return
                 }
             }
         }

--- a/src/features/Content/editor/createEditor.js
+++ b/src/features/Content/editor/createEditor.js
@@ -28,12 +28,28 @@ const withVoids = editor => {
 
 // slate normalizes the editor's content after every change
 // here we can add some custom constraints to our editor
-// for now, we need to ensure that an UL can only contain LI's
 
 const withNormalizing = editor => {
     const { normalizeNode } = editor
 
     editor.normalizeNode = ([node, path]) => {
+
+        // ensure that there are no elements 
+        // above the links-panel besides the title
+
+        // if elem is not the title nor links panel, 
+        // and located at [0, ...] or [1, ...]
+        // move it down
+        if (node.type
+            && node.type !== 'links' 
+            && node.type !== 'title' 
+            && path[0] < 2
+        ) {
+            Transforms.moveNodes(editor, { to: [2] })
+            return;
+        }
+
+        // ensure that an UL can only contain LI's
         if (node.type === 'ul') {
             const children = Node.children(editor, path)
             for (const [child] of children) {
@@ -43,6 +59,7 @@ const withNormalizing = editor => {
                 }
             }
         }
+
         normalizeNode([node, path])
     }
 

--- a/src/features/Content/editor/createEditor.js
+++ b/src/features/Content/editor/createEditor.js
@@ -34,21 +34,6 @@ const withNormalizing = editor => {
 
     editor.normalizeNode = ([node, path]) => {
 
-        // ensure that there are no elements 
-        // above the links-panel besides the title
-
-        // if elem is not the title nor links panel, 
-        // and located at [0, ...] or [1, ...]
-        // move it down
-        if (node.type
-            && node.type !== 'links' 
-            && node.type !== 'title' 
-            && path[0] < 2
-        ) {
-            Transforms.moveNodes(editor, { to: [2] })
-            return;
-        }
-
         // ensure that an UL can only contain LI's
         if (node.type === 'ul') {
             const children = Node.children(editor, path)

--- a/src/features/Content/editor/handleKeyDown.js
+++ b/src/features/Content/editor/handleKeyDown.js
@@ -75,6 +75,16 @@ export const handleKeyDown = (event, editor) => {
 // of the same type as the elem at the selection
 
 const handleEnter = (editor, event) => {
+
+    // if the user is inside the title elem
+    if (isInside(editor, 'title')) {
+        event.preventDefault()
+        return
+    }
+
+    // if the user is inside a block of code, 
+    // or has pressed shift+enter
+    // create a new line
     if (isInside(editor, 'code-block') || event.shiftKey) {
         editor.insertText('\n');
         event.preventDefault();

--- a/src/features/Content/editor/handleKeyDown.js
+++ b/src/features/Content/editor/handleKeyDown.js
@@ -76,20 +76,27 @@ export const handleKeyDown = (event, editor) => {
 
 const handleEnter = (editor, event) => {
 
+    // sometimes, when the user toggles off readOnly,
+    // and focuses at the end of the title
+    // selection is not being set for some reason
+    if (!editor.selection) {
+        event.preventDefault()
+    }
+    
     // if the user is inside the title elem
     if (isInside(editor, 'title')) {
         event.preventDefault()
         return
     }
 
-    // if the user is inside a block of code, 
-    // or has pressed shift+enter
-    // create a new line
+    // if the user is inside of a code-block
+    // or pressed shift+enter, create a new line
     if (isInside(editor, 'code-block') || event.shiftKey) {
         editor.insertText('\n');
         event.preventDefault();
     }
 }
+
 
 const handleTab = (editor, event) => {
     if (isInside(editor, 'code-block')) {


### PR DESCRIPTION
fixes #15

If the user will attempt to insert an element either between the title and the links bar, or in middle of the title, splitting it, the elem will be inserted right after the links bar.

Also, prevent default 'onEnter' behavior when the user's caret is inside the title element.