### PR TITLE
bugFix/17

### DIFF
--- a/src/features/Content/ContentEditor.js
+++ b/src/features/Content/ContentEditor.js
@@ -39,9 +39,7 @@ const ContentEditor = ({ content, updateContent }) => {
                     // must nullify the selection when quitting editing
                     // to prevent HoveringMenu from re-appearing at the same place
                     // when the user will start editing again
-                    console.log(editor.selection)
                     if (!readOnly) editor.selection = null
-                    console.log(editor.selection)
                     setReadOnly(!readOnly)
                 }} 
             />

--- a/src/features/Content/editor/commands.js
+++ b/src/features/Content/editor/commands.js
@@ -66,7 +66,7 @@ export const insertElem = (editor, type) => {
     // specify the explicit location where to insert the elem
     // and that would be right after the links panel
 
-    const insertAt = isInside(editor, 'title') ? [2] : null
+    const insertAt = isInside(editor, 'title') ? [2] : undefined
 
     if (type === 'ul') {
         insertUl(editor, insertAt)

--- a/src/features/Content/editor/createEditor.js
+++ b/src/features/Content/editor/createEditor.js
@@ -56,8 +56,10 @@ const withNormalizing = editor => {
 // make the links panel undeletable
 
 const withDelete = editor => {
-    const { deleteBackward } = editor
+    const { deleteBackward, deleteFragment } = editor
 
+    // this is getting called whenever the user
+    // attempts to delete a single character
     editor.deleteBackward = (...args) => {
         const anchor = editor.selection.anchor
 
@@ -67,8 +69,27 @@ const withDelete = editor => {
         if (anchor.path[0] == 2 && anchor.offset == 0) {
             return
         }
-        
+
+        // otherwise, call the default method
         deleteBackward(...args)
+    }
+
+    // this is getting called whenever the user 
+    // attempts to delete the selected range
+    editor.deleteFragment = (...args) => {
+
+        // iterate through all the nodes within the current selection
+        // and if the links panel is among them, skip
+
+        const [match] = Editor.nodes(editor, {
+            match: n => n.type === 'links',
+            at: editor.selection
+        })
+
+        if (match) return;
+
+        // otherwise, call the default method
+        deleteFragment(...args)
     }
 
     return editor;

--- a/src/features/Content/editor/createEditor.js
+++ b/src/features/Content/editor/createEditor.js
@@ -1,7 +1,7 @@
 
 import { isInside } from './'
 
-import { createEditor, Transforms, Node } from 'slate'
+import { createEditor, Transforms, Node, Range, Editor } from 'slate'
 import { withHistory } from 'slate-history'
 import { withReact } from 'slate-react'
 import { compose } from '@reduxjs/toolkit'
@@ -53,7 +53,30 @@ const withNormalizing = editor => {
 
 
 
+// make the links panel undeletable
+
+const withDelete = editor => {
+    const { deleteBackward } = editor
+
+    editor.deleteBackward = (...args) => {
+        const anchor = editor.selection.anchor
+
+        // if selection is at the start of the elem
+        // that is next to the panel, skip
+        
+        if (anchor.path[0] == 2 && anchor.offset == 0) {
+            return
+        }
+        
+        deleteBackward(...args)
+    }
+
+    return editor;
+}
+
+
 const createMyEditor = compose(
+    withDelete,
     withVoids,
     withNormalizing, 
     withHistory, 

--- a/src/features/HoveringMenu/Input.js
+++ b/src/features/HoveringMenu/Input.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
+import Icon from 'components/Icon'
 
 const Input = ({ 
     inputRef,
@@ -16,7 +17,7 @@ const Input = ({
             onClick={submit}
             // prevent focus
             onMouseDown={e => e.preventDefault()} >
-            <i className="fas fa-check-double"/>
+            <Icon icon='check-bold' size='1.15em' />
         </button>
     </Div>
 )
@@ -55,17 +56,15 @@ const Div = styled.div`
         top: 4px;
         right: 7px;
         font-size: 1.3rem;
-        padding: 4px;
+        height: 23px;
+        width: 23px;
         border: 1px solid var(--gray5);
         border-radius: 3px;
         box-shadow: 0 0 6px -1px black;
-        color: var(--gray1);
-        opacity: ${props => props.isShown ? 1 : 0};
-        transition: opacity 3s, .5s;
     }
 
-    button:hover {
-        color: var(--orange1);
+    button:hover path {
+       fill: var(--orange1);
     }
 `;
 

--- a/src/features/HoveringMenu/MenuControls.js
+++ b/src/features/HoveringMenu/MenuControls.js
@@ -49,19 +49,25 @@ const MenuControls = ({
     return (
         <>
             <Button tooltip='toggle Bold. Ctrl + B'
-                handleMouseDown={() => setMark(editor, 'bold', !isBold)}
+                handleMouseDown={() => {
+                    setMark(editor, 'bold', !isBold, selection.current)
+                }}
                 isActive={isBold} >
                     <b>B</b>
             </Button>
 
             <Button tooltip='toggle Italic. Ctrl + i'
-                handleMouseDown={() => setMark(editor, 'italic', !isItalic)}
+                handleMouseDown={() => {
+                    setMark(editor, 'italic', !isItalic, selection.current)
+                }}
                 isActive={isItalic}>
                     <i>I</i>
             </Button>
 
             <Button tooltip='toggle Code. Ctrl + `'
-                handleMouseDown={() => setMark(editor, 'code', !isCode)}
+                handleMouseDown={() => {
+                    setMark(editor, 'code', !isCode, selection.current)
+                }}
                 isActive={isCode} >
                     <Icon icon='code-tags' />
             </Button>

--- a/src/features/HoveringMenu/useHoveringMenu.js
+++ b/src/features/HoveringMenu/useHoveringMenu.js
@@ -9,8 +9,6 @@ const useHoveringMenu = (inputRef) => {
     const editor = useSlate()
     const { selection } = editor
 
-    console.log(selection)
-
     const readOnly = ReactEditor.isReadOnly(editor)
 
     useEffect(() => {

--- a/src/features/HoveringMenu/useHoveringMenu.js
+++ b/src/features/HoveringMenu/useHoveringMenu.js
@@ -9,6 +9,8 @@ const useHoveringMenu = (inputRef) => {
     const editor = useSlate()
     const { selection } = editor
 
+    console.log(selection)
+
     const readOnly = ReactEditor.isReadOnly(editor)
 
     useEffect(() => {


### PR DESCRIPTION
fixes #17 

Overridden the editor's **deleteBackward** and **deleteFragment** methods:

 - **deleteBackward** is called whenever the user attempts to delete a single character. Now it checks if the caret is currently at the start of the elem that is next to the links panel. If so, skips the deletion, otherwise calls the default deleteBackward

- **deleteFragment** is called whenever the user attempts to delete the selected range. Now it checks whether the panel is inside the selection. If so, skips the deletion, otherwise calls the default deleteFragment.