### PR TITLE
Fix HoveringMenu positioning

### DIFF
--- a/src/components/Portal.js
+++ b/src/components/Portal.js
@@ -1,7 +1,0 @@
-import { createPortal } from 'react-dom';
-
-const Portal = ({ children }) => (
-    createPortal(children, document.body)
-)
-
-export default Portal;

--- a/src/features/Content/ContentEditor.js
+++ b/src/features/Content/ContentEditor.js
@@ -50,8 +50,6 @@ const ContentEditor = ({ content, updateContent }) => {
 
                 <Editable readOnly={readOnly} />
 
-                <HoveringMenu />
-
                 <ContentFooter 
                     readOnly={readOnly}
                     edited={content.edited}

--- a/src/features/Content/Editable.js
+++ b/src/features/Content/Editable.js
@@ -6,6 +6,8 @@ import { handleKeyDown, decorate } from './editor';
 import renderElement from './renderElement';
 import renderLeaf from './renderLeaf';
 
+import HoveringMenu from 'features/HoveringMenu/HoveringMenu'
+
 
 const MyEditable = ({ readOnly }) => {
     const editor = useEditor()
@@ -18,11 +20,14 @@ const MyEditable = ({ readOnly }) => {
                 decorate={decorate}
                 renderElement={renderElement}
                 renderLeaf={renderLeaf} />
+
+            <HoveringMenu />
         </Container>
     )
 }
 
 const Container = styled.div`
+    position: relative;
     background-color: var(--gray5);
     box-shadow: inset 0 -12px 25px -15px black;
     scroll-behavior: smooth;

--- a/src/features/Content/editor/commands.js
+++ b/src/features/Content/editor/commands.js
@@ -22,9 +22,9 @@ export const isMarkActive = (editor, mark) => {
 // checks whether the caret is currently
 // inside of an elem of the given type
 
-export const isInside = (editor, type) => {
+export const isInside = (editor, ...types) => {
     const [match] = Editor.nodes(editor, {
-        match: n => n.type === type,
+        match: n => types.includes(n.type),
       })
     
     return !!match

--- a/src/features/Content/editor/createEditor.js
+++ b/src/features/Content/editor/createEditor.js
@@ -66,7 +66,7 @@ const withDelete = editor => {
         // if selection is at the start of the elem
         // that is next to the panel, skip
         
-        if (anchor.path[0] == 2 && anchor.offset == 0) {
+        if (anchor.path[0] === 2 && anchor.offset === 0) {
             return
         }
 

--- a/src/features/Content/editor/createEditor.js
+++ b/src/features/Content/editor/createEditor.js
@@ -1,7 +1,7 @@
 
 import { isInside } from './'
 
-import { createEditor, Transforms, Node, Range, Editor } from 'slate'
+import { createEditor, Transforms, Node } from 'slate'
 import { withHistory } from 'slate-history'
 import { withReact } from 'slate-react'
 import { compose } from '@reduxjs/toolkit'
@@ -77,18 +77,7 @@ const withDelete = editor => {
     // this is getting called whenever the user 
     // attempts to delete the selected range
     editor.deleteFragment = (...args) => {
-
-        // iterate through all the nodes within the current selection
-        // and if the links panel is among them, skip
-
-        const [match] = Editor.nodes(editor, {
-            match: n => n.type === 'links',
-            at: editor.selection
-        })
-
-        if (match) return;
-
-        // otherwise, call the default method
+        if (isInside(editor, 'links')) return;
         deleteFragment(...args)
     }
 

--- a/src/features/HoveringMenu/HoveringMenu.js
+++ b/src/features/HoveringMenu/HoveringMenu.js
@@ -2,7 +2,6 @@ import React, { Suspense, useRef } from 'react';
 import { AnimatePresence } from 'framer-motion';
 
 import useHoveringMenu from './useHoveringMenu'
-import Portal from 'components/Portal';
 const Menu = React.lazy(() => import('./Menu'));
 
 
@@ -13,11 +12,9 @@ const HoveringMenu = () => {
     return (
         <AnimatePresence>
             {isShown && (
-                <Portal>
-                    <Suspense fallback=' '>
-                        <Menu inputRef={inputRef} />
-                    </Suspense>
-                </Portal>
+                <Suspense fallback=' '>
+                    <Menu inputRef={inputRef} />
+                </Suspense>
             )}
         </AnimatePresence>
     )

--- a/src/features/HoveringMenu/Menu.js
+++ b/src/features/HoveringMenu/Menu.js
@@ -82,7 +82,7 @@ const Div = styled(motion.div)`
     border: 1px solid var(--gray4);
     position: absolute;
     z-index: 200;
-    box-shadow: 0 2px 10px 2px var(--black);
+    box-shadow: 0 2px 15px 2px black;
 `;
 
 export default Menu;

--- a/src/features/HoveringMenu/useHoveringMenu.js
+++ b/src/features/HoveringMenu/useHoveringMenu.js
@@ -15,10 +15,12 @@ const useHoveringMenu = (inputRef) => {
         // don't let the menu hide when the user focuses on the input
         if (inputRef.current === document.activeElement) return;
 
-        // if there's no selection, hide the menu
+        // if there's no selection, or in readOnly mode, 
+        // or the user selection is inside either a code block or the title
+        // don't show/hide the menu
         if (!selection 
             || Range.isCollapsed(selection) 
-            || isInside(editor, 'code-block')
+            || isInside(editor, 'code-block', 'title')
             || readOnly
         ) {
             setShown(false)

--- a/src/features/HoveringMenu/useMenuCoords.js
+++ b/src/features/HoveringMenu/useMenuCoords.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Range } from 'slate'
 import { useSlate, ReactEditor } from 'slate-react'
+import { isInside } from 'features/Content/editor'
 
 
 const useMenuCoords = (menu, isInputShown, selection) => {
@@ -8,7 +9,12 @@ const useMenuCoords = (menu, isInputShown, selection) => {
     const editor = useSlate();
 
     useEffect(() => {
-        if (Range.isCollapsed(selection)) return;
+        // if selection is collapsed, or the user's selection
+        // includes a code block or the title
+        // the menu is about to hide, don't do anything
+        const inside = isInside(editor, 'code-block', 'title')
+        const collapsed = Range.isCollapsed(selection)
+        if (inside || collapsed) return
 
         const range = ReactEditor.toDOMRange(editor, selection)
         const rect = range.getBoundingClientRect()
@@ -22,7 +28,7 @@ const useMenuCoords = (menu, isInputShown, selection) => {
 
         const elWidth = menu.current.offsetWidth
 
-        const y = rect.top - elHeight - 16;
+        const y = rect.top - elHeight - 20;
         const x = rect.left - elWidth / 2 + rect.width / 2;
 
         setCoords({ x, y })

--- a/src/features/HoveringMenu/useMenuCoords.js
+++ b/src/features/HoveringMenu/useMenuCoords.js
@@ -14,22 +14,27 @@ const useMenuCoords = (menu, isInputShown, selection) => {
         // the menu is about to hide, don't do anything
         const inside = isInside(editor, 'code-block', 'title')
         const collapsed = Range.isCollapsed(selection)
-        if (inside || collapsed) return
+        if (inside || collapsed || !menu.current) return
 
+        // selected text coords
         const range = ReactEditor.toDOMRange(editor, selection)
         const rect = range.getBoundingClientRect()
 
-        // the line below doesn't work, because this hook
+        // editor's scrollbar coords
+        const containerElem = menu.current.offsetParent
+        const cont = containerElem.getBoundingClientRect()
+        const contScroll = containerElem.scrollTop
+
+        // i wish i could simply use menu's offsetHeight, but this hook
         // is getting invoked before the input had a chance to open
-        // let h = el.offsetHeight
+        const menuHeight = 41 + (isInputShown ? 39 : 0);
+        const y = rect.top - cont.top + contScroll - menuHeight - 20;
 
-        const input = isInputShown ? 39 : 0;
-        const elHeight = 41 + input;
+        const menuWidth = menu.current.offsetWidth
+        const menuLeft = rect.left - menuWidth / 2 + rect.width / 2
 
-        const elWidth = menu.current.offsetWidth
-
-        const y = rect.top - elHeight - 20;
-        const x = rect.left - elWidth / 2 + rect.width / 2;
+        let x =  menuLeft - cont.left;
+        if (x < 8) x = 8;
 
         setCoords({ x, y })
 


### PR DESCRIPTION
fixes #12 
fixes #20

HoveringMenu is now rendered in the editable's container, and remains above the selected range when the container is being scrolled. 